### PR TITLE
Prevent variable masking

### DIFF
--- a/libraries/chef_vault_secret_provider.rb
+++ b/libraries/chef_vault_secret_provider.rb
@@ -67,15 +67,15 @@ class Chef::Provider::ChefVaultSecret < Chef::Provider::LWRPBase
       json = ::ChefVault::Item.load(new_resource.data_bag, new_resource.id)
       resource = Chef::Resource::ChefVaultSecret.new(new_resource.id)
       resource.raw_data json.to_hash
-      current_resource = resource
+      self.current_resource = resource
     rescue Net::HTTPServerException => e
       if e.response.code == '404'
-        current_resource = resource
+        self.current_resource = nil
       else
         raise
       end
     rescue ChefVault::Exceptions::KeysNotFound
-      current_resource = resource
+      self.current_resource = nil
     rescue OpenSSL::PKey::RSAError
       raise "#{$!.message} - on #{Chef::Config[:client_key]}, is the vault item encrypted with this client/user?"
     end


### PR DESCRIPTION
current_resource gets masked by a local variable if you use
current_resource = x without using self.

I also changed the assigned value to explicitly be nil in the error case.
I think that is what it gets set to anyway, but it seems less error prone to be explicit.