### PR TITLE
vault_item_exists? is inverted.

### DIFF
--- a/libraries/chef_vault_secret_provider.rb
+++ b/libraries/chef_vault_secret_provider.rb
@@ -93,6 +93,6 @@ class Chef::Provider::ChefVaultSecret < Chef::Provider::LWRPBase
   end
 
   def vault_item_exists?
-    current_resource.nil?
+    !current_resource.nil?
   end
 end


### PR DESCRIPTION
The item exists if the current_resource is not nil.