### PR TITLE
Add ability to specify the source via chef_gem.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 # limitations under the License.
 #
 default['chef-vault']['version'] = '~> 2.2'
+default['chef-vault']['gem_source'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,7 @@
 
 chef_gem 'chef-vault' do
   version node['chef-vault']['version']
+  source node['chef-vault']['gem_source'] if node['chef-vault']['gem_source']
   compile_time true if respond_to?(:compile_time)
 end
 


### PR DESCRIPTION
This adds an attribute which allows us to specify a `source` to the chef_gem resource. This is helpful for us folks without access to a gem server and simply want to setup HTTP or download gem.