### PR TITLE
Fixed chef_vault_item method and fallback behavior

### DIFF
--- a/libraries/chef_vault_item.rb
+++ b/libraries/chef_vault_item.rb
@@ -36,8 +36,9 @@ module ChefVaultItem
       ChefVault::Item.load(bag, item)
     rescue LoadError, ChefVault::Exceptions::KeysNotFound => err
       Chef::Log.warn("Missing gem 'chef-vault', use recipe[chef-vault] to install it first.") if err.kind_of? LoadError
-      if (fallback and err.kind_of?  ChefVault::Exceptions::KeysNotFound)
+      if fallback
         Chef::Log.warn("Failed to load vault item #{item} from #{bag}, falling back to data bags.")
+        raise "Found a data bag item for #{item}_keys, refusing to fallback to data bag" if Chef::DataBag.load(bag).key? "#{item}_keys"
         Chef::DataBagItem.load(bag, item)
       else
         raise 'Unable to load vault item and databag fallback is disabled'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,5 +3,5 @@ maintainer       'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Installs the chef-vault gem and provides chef_vault_item recipe helper'
-version          '1.2.5'
+version          '1.3.0'
 


### PR DESCRIPTION
This fixes the behavior of working without the vault gem and falling back to data bags (but no longer returning an empty string when access is denied).