### PR TITLE
Fix chef vault item loading and falling back to data bags

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,8 +1,9 @@
 This cookbook includes support for running tests via Test Kitchen (1.0). This has some requirements.
 
 1. You must be using the Git repository, rather than the downloaded cookbook from the Chef Community Site.
-2. You must have Vagrant 1.1 installed.
-3. You must have a "sane" Ruby 1.9.3 environment.
+2. You must have Vagrant >= 1.1 installed.
+3. You must have a "sane" Ruby 1.9.3 or higher environment.
+4. You should have a recent ChefDK installed.
 
 Once the above requirements are met, install the additional requirements:
 
@@ -11,12 +12,10 @@ Install the berkshelf plugin for vagrant, and berkshelf to your local Ruby envir
     vagrant plugin install vagrant-berkshelf
     gem install berkshelf
 
-Install Test Kitchen 1.0 (unreleased yet, use the alpha / prerelease version).
+Install Test Kitchen and kitchen-vagrant (you can skip this if you are using
+chefdk as it's already installed):
 
-    gem install test-kitchen --pre
-
-Install the Vagrant driver for Test Kitchen.
-
+    gem install test-kitchen
     gem install kitchen-vagrant
 
 Once the above are installed, you should be able to run Test Kitchen:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 # limitations under the License.
 #
 default['chef-vault']['version'] = '~> 2.2'
+default['chef-vault']['databag_fallback'] = true

--- a/libraries/chef_vault_item.rb
+++ b/libraries/chef_vault_item.rb
@@ -40,7 +40,11 @@ module ChefVaultItem
       ChefVault::Item.load(bag, item)
     else
       # We don't have a vault item, it must be a regular data bag
-      Chef::DataBagItem.load(bag, item)
+      if node['chef-vault']['databag_fallback']
+        Chef::DataBagItem.load(bag, item)
+      else
+        raise "Trying to load a regular data bag item #{item} from #{bag}, and databag_fallback is disabled"
+      end
     end
   end
 end

--- a/libraries/chef_vault_item.rb
+++ b/libraries/chef_vault_item.rb
@@ -30,15 +30,16 @@ module ChefVaultItem
   # Falls back to normal data bag item loading if the item isn't actually a
   # vault item.
   def chef_vault_item(bag, item)
-    begin
-      require 'chef-vault'
-    rescue LoadError
-      Chef::Log.warn("Missing gem 'chef-vault', use recipe[chef-vault] to install it first.")
-    end
-
-    begin
+    if Chef::DataBag.load(bag).key?("#{item}_keys")
+      # We have a vault item
+      begin
+        require 'chef-vault'
+      rescue LoadError
+        raise("Missing gem 'chef-vault', use recipe[chef-vault] to install it first.")
+      end
       ChefVault::Item.load(bag, item)
-    rescue ChefVault::Exceptions::KeysNotFound, ChefVault::Exceptions::SecretDecryption
+    else
+      # We don't have a vault item, it must be a regular data bag
       Chef::DataBagItem.load(bag, item)
     end
   end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -30,3 +30,16 @@ library_secret = test_chef_vault
 file '/tmp/chef-vault-secret-from-library' do
   content library_secret['auth']
 end
+
+# Verify that we raise an exception if databag fallback is disabled
+node.set['chef-vault']['databag_fallback'] = false
+begin
+  no_fallback_secret = chef_vault_item('secrets', 'dbpassword')
+rescue
+  no_fallback_secret = {"auth" => "exception raised"}
+end
+node.set['chef-vault']['databag_fallback'] = true
+
+file '/tmp/chef-vault-secret-no-fallback' do
+  content no_fallback_secret["auth"]
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -9,4 +9,7 @@ describe 'chef-vault::default' do
     its(:content) { should match(/success/) }
   end
 
+  describe file('/tmp/chef-vault-secret-no-fallback') do
+    its(:content) { should match(/exception raised/) }
+  end
 end


### PR DESCRIPTION
Pull request #14 introduced an issue where, if a vault item wasn't encrypted to you or otherwise was unable to be decrypted, you silently end up being given the raw, encrypted data instead instead of encountering an exception. This can lead to silent breakage when expected data is missing.

After some discussion (#26, #27), we have come up with this pull request, which provides the following behavior:

* Preserve the fall back to loading an unencrypted data bag item if the item we're trying to load isn't actually a vault item. This is useful in development and also to allow the same cookbook to be used with no changes by people who don't use chef-vault at all, but are sticking with regular data bags, while allowing them to seamlessly migrate to chef-vault at a later time.
* Allows this behavior to be disabled via an attribute if so required by policy.
* Only try to load the chef-vault gem if we are trying to load a vault item.
* Removes any exception catching (except for the LoadError to detect when chef-vault isn't installed). This was necessary to allow loading regular data bag items if chef-vault isn't installed, but also sidesteps the issue of which exceptions should be caught in order to fall back.